### PR TITLE
Add MCP server integration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/python:3.11"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+RUN apt-get update && apt-get install -y git build-essential rust-all nodejs npm && rm -rf /var/lib/apt/lists/*
+RUN pip install uvicorn[standard] fastapi
+WORKDIR /app
+COPY . .
+CMD ["python", "-m", "chia.mcp.server"]

--- a/chia/_tests/mcp/test_mcp_server.py
+++ b/chia/_tests/mcp/test_mcp_server.py
@@ -1,0 +1,14 @@
+import asyncio
+
+import pytest
+from httpx import AsyncClient
+
+from chia.mcp.server import app
+
+
+@pytest.mark.asyncio
+async def test_ping() -> None:
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        response = await ac.get("/mcp/ping")
+    assert response.json() == {"ping": "pong"}
+

--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -30,6 +30,7 @@ from chia.cmds.passphrase_funcs import default_passphrase, using_default_passphr
 from chia.consensus.coinbase import create_puzzlehash_for_pk
 from chia.daemon.keychain_server import KeychainServer, keychain_commands
 from chia.daemon.windows_signal import kill
+from chia.mcp.server import run_mcp_server
 from chia.plotters.plotters import get_available_plotters
 from chia.plotting.util import add_plot_directory
 from chia.server.server import ssl_context_for_server
@@ -37,7 +38,7 @@ from chia.server.signal_handlers import SignalHandlers
 from chia.util.bech32m import encode_puzzle_hash
 from chia.util.chia_logging import initialize_service_logging
 from chia.util.chia_version import chia_short_version
-from chia.util.config import load_config
+from chia.util.config import load_config, save_config
 from chia.util.errors import KeychainCurrentPassphraseIsInvalid
 from chia.util.json_util import dict_to_json_str
 from chia.util.keychain import Keychain, KeyData, passphrase_requirements, supports_os_passphrase_storage
@@ -1544,7 +1545,8 @@ async def async_run_daemon(root_path: Path, wait_for_unlock: bool = False) -> in
     # When wait_for_unlock is true, we want to skip the check_keys() call in chia_init
     # since it might be necessary to wait for the GUI to unlock the keyring first.
     chia_init(root_path, should_check_keys=(not wait_for_unlock))
-    config = load_config(root_path, "config.yaml")
+    config = load_config(root_path, "config.yaml", fill_missing_services=True)
+    save_config(root_path, "config.yaml", config)
     setproctitle("chia_daemon")
     initialize_service_logging("daemon", config, root_path=root_path)
     crt_path = root_path / config["daemon_ssl"]["private_crt"]
@@ -1574,7 +1576,15 @@ async def async_run_daemon(root_path: Path, wait_for_unlock: bool = False) -> in
             async with SignalHandlers.manage() as signal_handlers:
                 await ws_server.setup_process_global_state(signal_handlers=signal_handlers)
                 async with ws_server.run():
-                    await ws_server.shutdown_event.wait()
+                    mcp_task = None
+                    if config.get("mcp", {}).get("enable", False):
+                        mcp_task = create_referenced_task(run_mcp_server(config))
+                    try:
+                        await ws_server.shutdown_event.wait()
+                    finally:
+                        if mcp_task is not None:
+                            mcp_task.cancel()
+                            await cancel_task_safe(mcp_task)
 
             if beta_metrics is not None:
                 await beta_metrics.stop_logging()

--- a/chia/mcp/__init__.py
+++ b/chia/mcp/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from .server import run_mcp_server
+
+__all__ = ["run_mcp_server"]

--- a/chia/mcp/client_pool.py
+++ b/chia/mcp/client_pool.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+from chia.rpc.data_layer_rpc_client import DataLayerRpcClient
+from chia.rpc.farmer_rpc_client import FarmerRpcClient
+from chia.rpc.full_node_rpc_client import FullNodeRpcClient
+from chia.rpc.harvester_rpc_client import HarvesterRpcClient
+from chia.rpc.wallet_rpc_client import WalletRpcClient
+
+
+@dataclass
+class ClientPool:
+    wallet: Optional[WalletRpcClient] = None
+    full_node: Optional[FullNodeRpcClient] = None
+    farmer: Optional[FarmerRpcClient] = None
+    harvester: Optional[HarvesterRpcClient] = None
+    data_layer: Optional[DataLayerRpcClient] = None
+
+    async def start(self, config: dict[str, Any]) -> None:
+        root_path = Path(config["root_path"])
+        self.wallet = await WalletRpcClient.create(
+            self_hostname=config.get("self_hostname", "localhost"),
+            port=config["wallet"]["rpc_port"],
+            root_path=root_path,
+            net_config=config,
+        )
+        self.full_node = await FullNodeRpcClient.create(
+            self_hostname=config.get("self_hostname", "localhost"),
+            port=config["full_node"]["rpc_port"],
+            root_path=root_path,
+            net_config=config,
+        )
+        self.farmer = await FarmerRpcClient.create(
+            self_hostname=config.get("self_hostname", "localhost"),
+            port=config["farmer"]["rpc_port"],
+            root_path=root_path,
+            net_config=config,
+        )
+        self.harvester = await HarvesterRpcClient.create(
+            self_hostname=config.get("self_hostname", "localhost"),
+            port=config["harvester"]["rpc_port"],
+            root_path=root_path,
+            net_config=config,
+        )
+        if config.get("data_layer", {}).get("enable", False):
+            self.data_layer = await DataLayerRpcClient.create(
+                self_hostname=config.get("self_hostname", "localhost"),
+                port=config["data_layer"]["rpc_port"],
+                root_path=root_path,
+                net_config=config,
+            )
+
+    async def close(self) -> None:
+        tasks: list[Awaitable[None]] = []
+        for client in [self.wallet, self.full_node, self.farmer, self.harvester, self.data_layer]:
+            if client is not None:
+                tasks.append(client.close())
+        if tasks:
+            await asyncio.gather(*tasks)

--- a/chia/mcp/error.py
+++ b/chia/mcp/error.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+
+class MCPError(Exception):
+    def __init__(self, code: int, message: str) -> None:
+        self.code = code
+        self.message = message
+        super().__init__(message)
+
+    def to_dict(self) -> dict[str, int | str]:
+        return {"error": self.code, "message": self.message}

--- a/chia/mcp/registry.py
+++ b/chia/mcp/registry.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from chia.mcp.client_pool import ClientPool
+
+
+@dataclass
+class Tool:
+    group: str
+    name: str
+    schema: dict[str, Any]
+    handler: Callable[[ClientPool, dict[str, Any]], Awaitable[Any]]
+
+
+_registry: dict[tuple[str, str], Tool] = {}
+
+
+def mcp_tool(
+    group: str,
+    name: str,
+    schema: dict[str, Any],
+) -> Callable[
+    [Callable[[ClientPool, dict[str, Any]], Awaitable[Any]]],
+    Callable[[ClientPool, dict[str, Any]], Awaitable[Any]],
+]:
+    def decorator(
+        func: Callable[[ClientPool, dict[str, Any]], Awaitable[Any]]
+    ) -> Callable[[ClientPool, dict[str, Any]], Awaitable[Any]]:
+        _registry[group, name] = Tool(group, name, schema, func)
+        return func
+
+    return decorator
+
+
+def get_tool(group: str, name: str) -> Tool | None:
+    return _registry.get((group, name))
+
+
+def schema() -> list[dict[str, Any]]:
+    return [
+        {"group": tool.group, "name": tool.name, "schema": tool.schema}
+        for tool in _registry.values()
+    ]

--- a/chia/mcp/server.py
+++ b/chia/mcp/server.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import uvicorn
+from fastapi import FastAPI, HTTPException, WebSocket
+
+from chia.mcp.client_pool import ClientPool
+from chia.mcp.error import MCPError
+from chia.mcp.registry import get_tool, schema
+
+log = logging.getLogger(__name__)
+
+app = FastAPI()
+mcp_app = FastAPI()
+app.mount("/mcp", mcp_app)
+
+pool = ClientPool()
+
+
+@mcp_app.get("/ping")
+async def ping() -> dict[str, str]:
+    return {"ping": "pong"}
+
+
+@mcp_app.get("/schema.json")
+async def schema_endpoint() -> list[dict[str, Any]]:
+    return schema()
+
+
+@mcp_app.post("/{group}/{name}")
+async def call_tool(group: str, name: str, params: dict[str, Any]) -> Any:
+    tool = get_tool(group, name)
+    if tool is None:
+        raise HTTPException(status_code=404, detail="tool not found")
+    try:
+        return await tool.handler(pool, params)
+    except MCPError as e:
+        raise HTTPException(status_code=400, detail=e.to_dict())
+
+
+@mcp_app.websocket("/ws")
+async def websocket_endpoint(websocket: WebSocket) -> None:
+    await websocket.accept()
+    try:
+        while True:
+            data = await websocket.receive_json()
+            group = data.get("group")
+            name = data.get("name")
+            params = data.get("params", {})
+            tool = get_tool(group, name) if group and name else None
+            if tool is None:
+                await websocket.send_json({"error": "tool not found"})
+                continue
+            try:
+                result = await tool.handler(pool, params)
+                await websocket.send_json({"result": result})
+            except MCPError as e:
+                await websocket.send_json(e.to_dict())
+    except Exception:
+        pass
+
+
+async def run_mcp_server(config: dict[str, Any]) -> None:
+    mcp_conf = config.get("mcp", {})
+    host = config.get("self_hostname", "localhost")
+    port = mcp_conf.get("port", 8550)
+    ssl_cert = Path(mcp_conf.get("ssl", {}).get("private_crt", ""))
+    ssl_key = Path(mcp_conf.get("ssl", {}).get("private_key", ""))
+
+    certfile = str(ssl_cert) if ssl_cert.exists() else None
+    keyfile = str(ssl_key) if ssl_key.exists() else None
+
+    uv_config = uvicorn.Config(
+        app,
+        host=host,
+        port=port,
+        ssl_certfile=certfile,
+        ssl_keyfile=keyfile,
+        log_level="info",
+    )
+    server = uvicorn.Server(uv_config)
+    log.info("Starting MCP server on %s:%s", host, port)
+    await pool.start(config)
+    try:
+        await server.serve()
+    finally:
+        await pool.close()

--- a/chia/mcp/tools_wallet.py
+++ b/chia/mcp/tools_wallet.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import Any
+
+from chia.mcp.client_pool import ClientPool
+from chia.mcp.error import MCPError
+from chia.mcp.registry import mcp_tool
+
+
+@mcp_tool("wallet", "get_public_keys", schema={})
+async def get_public_keys(pool: ClientPool, params: dict[str, Any]) -> Any:
+    try:
+        assert pool.wallet is not None
+        return await pool.wallet.get_public_keys()
+    except Exception as e:
+        raise MCPError(1, str(e))
+
+
+@mcp_tool("wallet", "get_wallet_balance", schema={"wallet_id": int})
+async def get_wallet_balance(pool: ClientPool, params: dict[str, Any]) -> Any:
+    try:
+        assert pool.wallet is not None
+        wallet_id = int(params.get("wallet_id", 1))
+        return await pool.wallet.get_wallet_balance(wallet_id)
+    except Exception as e:
+        raise MCPError(1, str(e))

--- a/chia/util/config.py
+++ b/chia/util/config.py
@@ -307,7 +307,7 @@ def selected_network_address_prefix(config: dict[str, Any]) -> str:
 
 
 def load_defaults_for_missing_services(config: dict[str, Any], config_name: str) -> dict[str, Any]:
-    services = ["data_layer"]
+    services = ["data_layer", "mcp"]
     missing_services = [service for service in services if service not in config]
     defaulted = {}
     if len(missing_services) > 0:

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -661,6 +661,13 @@ data_layer:
   # Enable to store all .DAT files grouped by store id
   group_files_by_store: False
 
+mcp:
+  enable: False
+  port: 8550
+  ssl:
+    private_crt: "config/ssl/daemon/private_daemon.crt"
+    private_key: "config/ssl/daemon/private_daemon.key"
+
 simulator:
   # Should the simulator farm a block whenever a transaction is in mempool
   auto_farm: True

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,11 @@
+# Model Context Protocol (MCP)
+
+The MCP server exposes Chia RPCs via HTTP and WebSocket. Enable it in `config.yaml`:
+
+```yaml
+mcp:
+  enable: true
+  port: 8550
+```
+
+Start the daemon and access `/mcp/ping` to verify. Available tools are listed at `/mcp/schema.json`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,8 @@ setuptools = ">=75.5.0"
 sortedcontainers = ">=2.4.0"  # For maintaining sorted mempools
 typing-extensions = ">=4.12.2"  # typing backports like Protocol and TypedDict
 watchdog = ">=4.0.1"  # Filesystem event watching - watches keyring.yaml
+fastapi = ">=0.109"
+uvicorn = { version = ">=0.29", extras = ["standard"] }
 zstd = [
 	{version=">=1.5.5.1", python = "<3.12"},
 	{version=">=1.5.5.1", python = "3.12", source="chia"},

--- a/requirements-mcp.txt
+++ b/requirements-mcp.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn[standard]
+pytest-asyncio
+aiofiles


### PR DESCRIPTION
## Summary
- add FastAPI dependencies and requirements file
- implement MCP client pool, registry, and wallet tools
- integrate MCP server with daemon
- add ping test and documentation
- provide Dockerfile and devcontainer for MCP

## Testing
- `ruff check chia/mcp/server.py chia/mcp/client_pool.py chia/mcp/registry.py chia/mcp/tools_wallet.py chia/mcp/error.py chia/daemon/server.py`
- `mypy --strict chia/mcp/server.py chia/mcp/client_pool.py chia/mcp/registry.py chia/mcp/tools_wallet.py chia/mcp/error.py` *(fails: missing imports)*
- `pytest chia/_tests/mcp/test_mcp_server.py -q` *(command not found)*