### PR TITLE
feat: expose pooling helpers

### DIFF
--- a/chia/mcp/client_pool.py
+++ b/chia/mcp/client_pool.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any, Optional
+
+from chia_rs.sized_ints import uint16
+
+from chia.rpc.data_layer_rpc_client import DataLayerRpcClient
+from chia.rpc.farmer_rpc_client import FarmerRpcClient
+from chia.rpc.full_node_rpc_client import FullNodeRpcClient
+from chia.rpc.harvester_rpc_client import HarvesterRpcClient
+from chia.rpc.rpc_client import RpcClient
+from chia.rpc.wallet_rpc_client import WalletRpcClient
+from chia.util.config import load_config
+from chia.util.default_root import DEFAULT_ROOT_PATH
+from chia.util.task_referencer import create_referenced_task
+
+CLIENT_TYPES: dict[str, type[RpcClient]] = {
+    "wallet": WalletRpcClient,
+    "full_node": FullNodeRpcClient,
+    "farmer": FarmerRpcClient,
+    "harvester": HarvesterRpcClient,
+    "data_layer": DataLayerRpcClient,
+}
+
+TOOL_GROUP_TO_CLIENT: dict[str, str] = {
+    "wallet": "wallet",
+    "node": "full_node",
+    "farmer": "farmer",
+    "harvester": "harvester",
+    "data": "data_layer",
+    "data_layer": "data_layer",
+}
+
+
+class ClientPool:
+    """Manage connections for RPC clients with automatic reconnection."""
+
+    def __init__(self, root_path: Optional[Path] = None) -> None:
+        self.root_path = root_path or DEFAULT_ROOT_PATH
+        self._clients: dict[str, RpcClient] = {}
+        self._config: Optional[dict[str, Any]] = None
+        self._lock = asyncio.Lock()
+
+    async def initialize(self) -> None:
+        self._config = load_config(self.root_path, "config.yaml", fill_missing_services=True)
+        tasks = [create_referenced_task(self._connect(name, cls)) for name, cls in CLIENT_TYPES.items()]
+        await asyncio.gather(*tasks)
+
+    async def _connect(self, name: str, cls: type[RpcClient]) -> None:
+        assert self._config is not None
+        host = self._config["self_hostname"]
+        port = uint16(self._config[name]["rpc_port"])
+        while True:
+            try:
+                client = await cls.create(host, port, self.root_path, self._config)
+                await client.healthz()
+                async with self._lock:
+                    old = self._clients.get(name)
+                    self._clients[name] = client
+                    if old is not None:
+                        old.close()
+                        await old.await_closed()
+                break
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                await asyncio.sleep(5)
+
+    async def _get_or_reconnect(self, name: str) -> RpcClient:
+        async with self._lock:
+            client = self._clients.get(name)
+        if client is None:
+            await self._connect(name, CLIENT_TYPES[name])
+            async with self._lock:
+                client = self._clients[name]
+        else:
+            try:
+                await client.healthz()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                await self._connect(name, CLIENT_TYPES[name])
+                async with self._lock:
+                    client = self._clients[name]
+        return client
+
+    async def get_client(self, tool_group: str) -> RpcClient:
+        name = TOOL_GROUP_TO_CLIENT.get(tool_group)
+        if name is None:
+            raise ValueError(f"Unknown tool group: {tool_group}")
+        return await self._get_or_reconnect(name)
+
+    async def close(self) -> None:
+        async with self._lock:
+            clients = list(self._clients.values())
+            self._clients.clear()
+        for client in clients:
+            client.close()
+            await client.await_closed()
+
+
+_pool: Optional[ClientPool] = None
+
+
+async def init_pool(root_path: Optional[Path] = None) -> None:
+    global _pool
+    pool = ClientPool(root_path)
+    await pool.initialize()
+    _pool = pool
+
+
+async def get_client(tool_group: str) -> RpcClient:
+    if _pool is None:
+        await init_pool()
+    assert _pool is not None
+    return await _pool.get_client(tool_group)

--- a/chia/mcp/pool.py
+++ b/chia/mcp/pool.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from chia.types.transaction_record import TransactionRecord
+from chia_rs.sized_bytes import bytes32
+from chia_rs.sized_ints import uint32, uint64
+
+from chia.mcp.client_pool import get_client
+from chia.pools.pool_wallet_info import PoolWalletInfo
+from chia.rpc.farmer_rpc_client import FarmerRpcClient
+from chia.rpc.wallet_rpc_client import WalletRpcClient
+
+
+async def _wallet() -> WalletRpcClient:
+    client = await get_client("wallet")
+    assert isinstance(client, WalletRpcClient)
+    return client
+
+
+async def _farmer() -> FarmerRpcClient:
+    client = await get_client("farmer")
+    assert isinstance(client, FarmerRpcClient)
+    return client
+
+
+async def create_new_pool_wallet(
+    target_puzzlehash: Optional[bytes32],
+    pool_url: Optional[str],
+    relative_lock_height: uint32,
+    backup_host: str,
+    mode: str,
+    state: str,
+    fee: uint64,
+    p2_singleton_delay_time: Optional[uint64] = None,
+    p2_singleton_delayed_ph: Optional[bytes32] = None,
+    extra_conditions: tuple[Any, ...] = tuple(),
+) -> TransactionRecord:
+    """Create a new pool wallet via the wallet RPC."""
+    wallet = await _wallet()
+    return await wallet.create_new_pool_wallet(
+        target_puzzlehash,
+        pool_url,
+        relative_lock_height,
+        backup_host,
+        mode,
+        state,
+        fee,
+        p2_singleton_delay_time,
+        p2_singleton_delayed_ph,
+        extra_conditions,
+    )
+
+
+async def pw_self_pool(wallet_id: int, fee: uint64) -> dict[str, Any]:
+    """Leave a pool and revert to self pooling."""
+    wallet = await _wallet()
+    return await wallet.pw_self_pool(wallet_id, fee)
+
+
+async def pw_join_pool(
+    wallet_id: int,
+    target_puzzlehash: bytes32,
+    pool_url: str,
+    relative_lock_height: uint32,
+    fee: uint64,
+) -> dict[str, Any]:
+    """Join a pool with the specified parameters."""
+    wallet = await _wallet()
+    return await wallet.pw_join_pool(
+        wallet_id,
+        target_puzzlehash,
+        pool_url,
+        relative_lock_height,
+        fee,
+    )
+
+
+async def pw_absorb_rewards(
+    wallet_id: int,
+    fee: uint64 = uint64(0),
+    max_spends_in_tx: Optional[int] = None,
+) -> dict[str, Any]:
+    """Claim rewards for a pool wallet."""
+    wallet = await _wallet()
+    return await wallet.pw_absorb_rewards(wallet_id, fee, max_spends_in_tx)
+
+
+async def pw_status(wallet_id: int) -> tuple[PoolWalletInfo, list[TransactionRecord]]:
+    """Return the pooling status for a wallet."""
+    wallet = await _wallet()
+    return await wallet.pw_status(wallet_id)
+
+
+async def get_pool_state() -> dict[str, Any]:
+    """Return pooling state from the farmer."""
+    farmer = await _farmer()
+    return await farmer.get_pool_state()
+
+
+async def set_payout_instructions(launcher_id: bytes32, payout_instructions: str) -> dict[str, Any]:
+    """Update payout instructions for a pool launcher."""
+    farmer = await _farmer()
+    return await farmer.set_payout_instructions(launcher_id, payout_instructions)
+
+
+async def set_reward_targets(
+    farmer_target: Optional[str] = None,
+    pool_target: Optional[str] = None,
+) -> dict[str, Any]:
+    """Update farmer and pool reward targets."""
+    farmer = await _farmer()
+    return await farmer.set_reward_targets(farmer_target, pool_target)
+
+
+async def get_pool_login_link(launcher_id: bytes32) -> Optional[str]:
+    """Return the login link for a pool dashboard."""
+    farmer = await _farmer()
+    return await farmer.get_pool_login_link(launcher_id)
+
+
+async def get_pool_stats() -> dict[str, Any]:
+    """Convenience helper returning farmer pooling statistics."""
+    return await get_pool_state()


### PR DESCRIPTION
## Summary
- manage RPC reconnection cancellation handling
- expose pooling RPC helper functions via MCP

## Testing
- `ruff check chia/mcp/client_pool.py chia/mcp/pool.py`
- `ruff format chia/mcp/client_pool.py chia/mcp/pool.py`
- `mypy chia/mcp/client_pool.py chia/mcp/pool.py` *(fails: missing stubs)*