### PR TITLE
Add MCP tool modules

### DIFF
--- a/chia/mcp/__init__.py
+++ b/chia/mcp/__init__.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable
+from typing import Any, Callable, TypeVar
+
+T = TypeVar("T", bound=Callable[..., Awaitable[Any]])
+
+
+def mcp_tool(schema: dict[str, Any]) -> Callable[[T], T]:
+    """Decorator to attach MCP metadata to a tool function."""
+
+    def decorator(func: T) -> T:
+        setattr(func, "mcp_schema", schema)
+        return func
+
+    return decorator

--- a/chia/mcp/tools_cat.py
+++ b/chia/mcp/tools_cat.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Any
+
+from chia_rs.sized_ints import uint64
+
+from chia.mcp import mcp_tool
+from chia.rpc.wallet_request_types import GetCATListResponse
+from chia.rpc.wallet_rpc_client import WalletRpcClient
+
+
+@mcp_tool({"request": "amount,fee,test", "response": "dict"})
+async def create_new_cat_and_wallet(
+    rpc: WalletRpcClient, amount: int, fee: int = 0, test: bool = False
+) -> dict[str, Any]:
+    return await rpc.create_new_cat_and_wallet(uint64(amount), uint64(fee), test)
+
+
+@mcp_tool({"request": "none", "response": "GetCATListResponse"})
+async def get_cat_list(rpc: WalletRpcClient) -> GetCATListResponse:
+    return await rpc.get_cat_list()

--- a/chia/mcp/tools_data_layer.py
+++ b/chia/mcp/tools_data_layer.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from chia_rs.sized_bytes import bytes32
+from chia_rs.sized_ints import uint64
+
+from chia.mcp import mcp_tool
+from chia.rpc.data_layer_rpc_client import DataLayerRpcClient
+
+
+@mcp_tool({"request": "fee,verbose", "response": "dict"})
+async def create_data_store(
+    rpc: DataLayerRpcClient,
+    fee: Optional[int] = None,
+    verbose: bool = False,
+) -> dict[str, Any]:
+    fee_uint = uint64(fee) if fee is not None else None
+    return await rpc.create_data_store(fee_uint, verbose)
+
+
+@mcp_tool({"request": "store_id,key", "response": "dict"})
+async def get_value(
+    rpc: DataLayerRpcClient,
+    store_id: bytes32,
+    key: bytes,
+) -> dict[str, Any]:
+    return await rpc.get_value(store_id, key, None)

--- a/chia/mcp/tools_did_vc.py
+++ b/chia/mcp/tools_did_vc.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from chia.mcp import mcp_tool
+from chia.rpc.wallet_request_types import VCGet, VCGetResponse, VCMint, VCMintResponse
+from chia.rpc.wallet_rpc_client import WalletRpcClient
+
+
+@mcp_tool({"request": "VCMint", "response": "VCMintResponse"})
+async def vc_mint(rpc: WalletRpcClient, request: VCMint) -> VCMintResponse:
+    return await rpc.vc_mint(request)
+
+
+@mcp_tool({"request": "VCGet", "response": "VCGetResponse"})
+async def vc_get(rpc: WalletRpcClient, request: VCGet) -> VCGetResponse:
+    return await rpc.vc_get(request)

--- a/chia/mcp/tools_farmer_harvester.py
+++ b/chia/mcp/tools_farmer_harvester.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import Any
+
+from chia.mcp import mcp_tool
+from chia.rpc.farmer_rpc_client import FarmerRpcClient
+from chia.rpc.harvester_rpc_client import HarvesterRpcClient
+
+
+@mcp_tool({"request": "none", "response": "dict"})
+async def get_harvesters(rpc: FarmerRpcClient) -> dict[str, Any]:
+    return await rpc.get_harvesters()
+
+
+@mcp_tool({"request": "none", "response": "dict"})
+async def get_plots(rpc: HarvesterRpcClient) -> dict[str, Any]:
+    return await rpc.get_plots()

--- a/chia/mcp/tools_full_node.py
+++ b/chia/mcp/tools_full_node.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from chia_rs import FullBlock
+from chia_rs.sized_bytes import bytes32
+
+from chia.mcp import mcp_tool
+from chia.rpc.full_node_rpc_client import FullNodeRpcClient
+
+
+@mcp_tool({"request": "none", "response": "dict"})
+async def get_blockchain_state(rpc: FullNodeRpcClient) -> dict[str, Any]:
+    return await rpc.get_blockchain_state()
+
+
+@mcp_tool({"request": "header_hash", "response": "FullBlock|None"})
+async def get_block(rpc: FullNodeRpcClient, header_hash: bytes32) -> Optional[FullBlock]:
+    return await rpc.get_block(header_hash)

--- a/chia/mcp/tools_offers.py
+++ b/chia/mcp/tools_offers.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Any
+
+from chia.mcp import mcp_tool
+from chia.rpc.wallet_rpc_client import WalletRpcClient
+from chia.wallet.trade_record import TradeRecord
+from chia.wallet.trading.offer import Offer
+from chia.wallet.util.tx_config import TXConfig
+
+
+@mcp_tool({"request": "offer_dict,fee", "response": "CreateOfferForIDsResponse"})
+async def create_offer_for_ids(
+    rpc: WalletRpcClient,
+    offer_dict: dict[str, int],
+    fee: int = 0,
+) -> Any:
+    return await rpc.create_offer_for_ids(offer_dict, TXConfig(), fee=fee)
+
+
+@mcp_tool({"request": "offer,fee", "response": "TakeOfferResponse"})
+async def take_offer(rpc: WalletRpcClient, offer: Offer, fee: int = 0) -> Any:
+    return await rpc.take_offer(offer, TXConfig(), fee=fee)
+
+
+@mcp_tool({"request": "start,end", "response": "list[TradeRecord]"})
+async def get_all_offers(
+    rpc: WalletRpcClient,
+    start: int = 0,
+    end: int = 50,
+) -> list[TradeRecord]:
+    return await rpc.get_all_offers(start=start, end=end)

--- a/chia/mcp/tools_wallet.py
+++ b/chia/mcp/tools_wallet.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from chia_rs.sized_ints import uint32
+
+from chia.mcp import mcp_tool
+from chia.rpc.wallet_request_types import LogIn, LogInResponse
+from chia.rpc.wallet_rpc_client import WalletRpcClient
+
+
+@mcp_tool({"request": "LogIn", "response": "LogInResponse"})
+async def log_in(rpc: WalletRpcClient, fingerprint: int) -> LogInResponse:
+    return await rpc.log_in(LogIn(uint32(fingerprint)))
+
+
+@mcp_tool({"request": "wallet_id:int", "response": "WalletBalance"})
+async def get_wallet_balance(rpc: WalletRpcClient, wallet_id: int) -> dict[str, Any]:
+    return await rpc.get_wallet_balance(wallet_id)
+
+
+@mcp_tool({"request": "wallet_type", "response": "list"})
+async def get_wallets(rpc: WalletRpcClient, wallet_type: Optional[int] = None) -> list[dict[str, Any]]:
+    return await rpc.get_wallets(wallet_type)


### PR DESCRIPTION
## Summary
- add mcp tooling modules wrapping RPC clients for wallet, CAT, offers, data layer, DID/VC, full node, farmer and harvester
- provide simple `mcp_tool` decorator

## Testing
- `ruff check chia/mcp/__init__.py chia/mcp/tools_wallet.py chia/mcp/tools_cat.py chia/mcp/tools_offers.py chia/mcp/tools_data_layer.py chia/mcp/tools_did_vc.py chia/mcp/tools_full_node.py chia/mcp/tools_farmer_harvester.py`
- `mypy --config-file mypy.ini chia/mcp/__init__.py chia/mcp/tools_wallet.py chia/mcp/tools_cat.py chia/mcp/tools_offers.py chia/mcp/tools_data_layer.py chia/mcp/tools_did_vc.py chia/mcp/tools_full_node.py chia/mcp/tools_farmer_harvester.py` *(fails: Argument 2 to NewType ...)*
- `python -m pytest -q chia/mcp` *(fails: No module named pytest)*
