### PR TITLE
Potential fix for code scanning alert no. 8: Information exposure through an exception

### DIFF
--- a/chia/rpc/util.py
+++ b/chia/rpc/util.py
@@ -83,10 +83,7 @@ def wrap_http_handler(
         except Exception as e:
             tb = traceback.format_exc()
             log.warning(f"Error while handling message: {tb}")
-            if len(e.args) > 0:
-                res_object = {"success": False, "error": f"{e.args[0]}", "traceback": f"{tb}"}
-            else:
-                res_object = {"success": False, "error": f"{e}"}
+            res_object = {"success": False, "error": "An internal error has occurred."}
 
         return obj_to_response(res_object)
 


### PR DESCRIPTION
Potential fix for [https://github.com/darbotlabs/darbot-chia/security/code-scanning/8](https://github.com/darbotlabs/darbot-chia/security/code-scanning/8)

To fix the issue, we need to ensure that stack trace information is not exposed to external users. Instead, we should log the stack trace on the server for debugging purposes and return a generic error message to the user. This involves modifying the `wrap_http_handler` function in `chia/rpc/util.py` to exclude the `traceback` field from the response object and updating the `obj_to_response` function in `chia/util/json_util.py` to handle sanitized error messages.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
