### PR TITLE
Fix CodeQL warning for passphrase warning output

### DIFF
--- a/chia/cmds/passphrase_funcs.py
+++ b/chia/cmds/passphrase_funcs.py
@@ -67,7 +67,7 @@ def prompt_to_save_passphrase() -> bool:
             if warning is not None:
                 colorama.init()
 
-                print(warning)
+                print(warning)  # lgtm [py/clear-text-logging-sensitive-data]
             save = click.confirm(f"Would you like to save your passphrase to the {location}?", default=None)
 
     except Exception as e:


### PR DESCRIPTION
## Summary
- mark passphrase warning printing as safe to avoid logging false positive

## Testing
- `ruff format chia/cmds/passphrase_funcs.py`
- `ruff check --fix chia/cmds/passphrase_funcs.py`
- `mypy chia/cmds/passphrase_funcs.py` *(fails: cannot find module 'aiohttp' etc.)*
- `pytest -c /dev/null chia/_tests -v --durations 0` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_683bce58dcc8832895408add51ef0189